### PR TITLE
fix error handler support

### DIFF
--- a/src/wrapHandlers.mjs
+++ b/src/wrapHandlers.mjs
@@ -28,7 +28,7 @@ export function wrapNonWebsocket(fn) {
     if (WebSocketWrapper.isInstance(res)) {
       next('route');
     } else {
-      fn(req, res, next);
+      (async () => fn(req, res, next))().catch(next);
     }
   };
 }

--- a/src/wrapHandlers.mjs
+++ b/src/wrapHandlers.mjs
@@ -28,7 +28,7 @@ export function wrapNonWebsocket(fn) {
     if (WebSocketWrapper.isInstance(res)) {
       next('route');
     } else {
-      (async () => fn(req, res, next))().catch(next);
+      return fn(req, res, next);
     }
   };
 }


### PR DESCRIPTION
make Router behave as same as Router in express 5.0
I have a repo https://github.com/steve02081504/fount that depends on websocket-express and error hanlders so it would be helpful if a new version could be released soon, thanks!